### PR TITLE
Fixed formatting of a Note in Training-Plugins.md

### DIFF
--- a/docs/Training-Plugins.md
+++ b/docs/Training-Plugins.md
@@ -3,7 +3,7 @@
 ML-Agents provides support for running your own python implementations of specific interfaces during the training
 process. These interfaces are currently fairly limited, but will be expanded in the future.
 
-** Note ** Plugin interfaces should currently be considered "in beta", and they may change in future releases.
+**Note:** Plugin interfaces should currently be considered "in beta", and they may change in future releases.
 
 ## How to Write Your Own Plugin
 [This video](https://www.youtube.com/watch?v=fY3Y_xPKWNA) explains the basics of how to create a plugin system using


### PR DESCRIPTION
Corrected a "Note" heading that should be bolded.

### Proposed change(s)

Markdown formatting of a **Note** was applied.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
